### PR TITLE
Print bindings.rs location in debug mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,4 +38,9 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+    #[cfg(debug_assertions)]
+    println!(
+        "cargo:warning=Generated bindings: {}",
+        out_path.join("bindings.rs").display()
+    );
 }


### PR DESCRIPTION
Just a small quality of life: print generated `bindings.rs` location in debug mode only.