### PR TITLE
Support maths types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +455,7 @@ dependencies = [
  "const-combine",
  "const-crc32",
  "log",
+ "mint",
  "once_cell",
  "sealed",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4", optional = true }
 chrono-tz = { version = "0.9", optional = true }
+mint = { version = "0.5", optional = true }
 time = { version = "0.3", optional = true }
 thiserror = "1"
 sealed = "0.5"
@@ -22,6 +23,7 @@ cmake = "0.1"
 [features]
 default = []
 chrono = ["dep:chrono", "dep:chrono-tz"]
+mint = ["dep:mint"]
 time = ["dep:time"]
 log = ["dep:log"]
 

--- a/deps/wrapper.hpp
+++ b/deps/wrapper.hpp
@@ -1,4 +1,5 @@
 #include <RED4ext/RED4ext.hpp>
+#include <RED4ext/Scripting/Natives/Generated/Vector4.hpp>
 #include <RED4ext/Scripting/Natives/entEntityID.hpp>
 #include <RED4ext/Scripting/Natives/GameTime.hpp>
 #include <RED4ext/Scripting/Natives/Generated/EngineTime.hpp>

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,6 +12,8 @@ mod res;
 pub use res::{RaRef, ResRef};
 mod tweak_db_id;
 pub use tweak_db_id::TweakDbId;
+mod maths;
+pub use maths::{EulerAngles, Quaternion, Vector2, Vector3, Vector4};
 mod array;
 pub use array::{IntoIter, RedArray};
 mod refs;

--- a/src/types/maths.rs
+++ b/src/types/maths.rs
@@ -1,0 +1,238 @@
+use crate::raw::root::RED4ext as red;
+use crate::repr::NativeRepr;
+
+#[repr(transparent)]
+pub struct Vector2(red::Vector2);
+
+impl Vector2 {
+    #[inline]
+    pub fn x(&self) -> f32 {
+        self.0.X
+    }
+
+    #[inline]
+    pub fn y(&self) -> f32 {
+        self.0.Y
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Vector2<f32>> for Vector2 {
+    fn from(value: mint::Vector2<f32>) -> Self {
+        Self(red::Vector2 {
+            X: value.x,
+            Y: value.y,
+        })
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Vector2> for mint::Vector2<f32> {
+    fn from(value: Vector2) -> Self {
+        Self {
+            x: value.0.X,
+            y: value.0.Y,
+        }
+    }
+}
+
+unsafe impl NativeRepr for Vector2 {
+    const NAME: &'static str = "Vector2";
+}
+
+#[repr(transparent)]
+pub struct Vector3(red::Vector3);
+
+impl Vector3 {
+    #[inline]
+    pub fn x(&self) -> f32 {
+        self.0.X
+    }
+
+    #[inline]
+    pub fn y(&self) -> f32 {
+        self.0.Y
+    }
+
+    #[inline]
+    pub fn z(&self) -> f32 {
+        self.0.Z
+    }
+}
+
+unsafe impl NativeRepr for Vector3 {
+    const NAME: &'static str = "Vector3";
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Vector3<f32>> for Vector3 {
+    fn from(value: mint::Vector3<f32>) -> Self {
+        Self(red::Vector3 {
+            X: value.x,
+            Y: value.y,
+            Z: value.z,
+        })
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Vector3> for mint::Vector3<f32> {
+    fn from(value: Vector3) -> Self {
+        Self {
+            x: value.0.X,
+            y: value.0.Y,
+            z: value.0.Z,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct Vector4(red::Vector4);
+
+impl Vector4 {
+    #[inline]
+    pub fn x(&self) -> f32 {
+        self.0.X
+    }
+
+    #[inline]
+    pub fn y(&self) -> f32 {
+        self.0.Y
+    }
+
+    #[inline]
+    pub fn z(&self) -> f32 {
+        self.0.Z
+    }
+
+    #[inline]
+    pub fn w(&self) -> f32 {
+        self.0.W
+    }
+}
+
+unsafe impl NativeRepr for Vector4 {
+    const NAME: &'static str = "Vector4";
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Vector4<f32>> for Vector4 {
+    fn from(value: mint::Vector4<f32>) -> Self {
+        Self(red::Vector4 {
+            X: value.x,
+            Y: value.y,
+            Z: value.z,
+            W: value.w,
+        })
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Vector4> for mint::Vector4<f32> {
+    fn from(value: Vector4) -> Self {
+        Self {
+            x: value.0.X,
+            y: value.0.Y,
+            z: value.0.Z,
+            w: value.0.W,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct Quaternion(red::Quaternion);
+
+impl Quaternion {
+    #[inline]
+    pub fn i(&self) -> f32 {
+        self.0.i
+    }
+
+    #[inline]
+    pub fn j(&self) -> f32 {
+        self.0.j
+    }
+
+    #[inline]
+    pub fn k(&self) -> f32 {
+        self.0.k
+    }
+
+    #[inline]
+    pub fn r(&self) -> f32 {
+        self.0.r
+    }
+}
+
+unsafe impl NativeRepr for Quaternion {
+    const NAME: &'static str = "Quaternion";
+}
+
+#[cfg(feature = "mint")]
+impl From<mint::Quaternion<f32>> for Quaternion {
+    fn from(value: mint::Quaternion<f32>) -> Self {
+        Self(red::Quaternion {
+            i: value.v.x,
+            j: value.v.y,
+            k: value.v.z,
+            r: value.s,
+        })
+    }
+}
+
+#[cfg(feature = "mint")]
+impl From<Quaternion> for mint::Quaternion<f32> {
+    fn from(value: Quaternion) -> Self {
+        Self {
+            v: mint::Vector3 {
+                x: value.0.i,
+                y: value.0.j,
+                z: value.0.k,
+            },
+            s: value.0.r,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct EulerAngles(red::EulerAngles);
+
+impl EulerAngles {
+    #[inline]
+    pub fn roll(&self) -> f32 {
+        self.0.Roll
+    }
+
+    #[inline]
+    pub fn pitch(&self) -> f32 {
+        self.0.Pitch
+    }
+
+    #[inline]
+    pub fn yaw(&self) -> f32 {
+        self.0.Yaw
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<B> From<mint::EulerAngles<f32, B>> for EulerAngles {
+    fn from(value: mint::EulerAngles<f32, B>) -> Self {
+        Self(red::EulerAngles {
+            Roll: value.c,
+            Pitch: value.a,
+            Yaw: value.b,
+        })
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<B> From<EulerAngles> for mint::EulerAngles<f32, B> {
+    fn from(value: EulerAngles) -> Self {
+        Self {
+            c: value.0.Roll,
+            a: value.0.Pitch,
+            b: value.0.Yaw,
+            marker: std::marker::PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for `Vector2/3/4`, `Quaternion` and `EulerAngles`, alongside optional feature to convert them back and forth with [mint](https://crates.io/crates/mint) (very useful for interoperability, if only with [kira](https://crates.io/crates/kira) but probably other crates too).