### PR TITLE
Fix enum and expose more properties

### DIFF
--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -837,6 +837,11 @@ impl Enum {
     }
 
     #[inline]
+    pub fn size(&self) -> u8 {
+        self.0.actualSize
+    }
+
+    #[inline]
     pub fn as_type(&self) -> &Type {
         unsafe { &*(self as *const _ as *const Type) }
     }

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -828,7 +828,7 @@ impl Enum {
 
     #[inline]
     pub fn variant_names(&self) -> &RedArray<CName> {
-        unsafe { mem::transmute(&self.0.aliasList) }
+        unsafe { mem::transmute(&self.0.hashList) }
     }
 
     #[inline]

--- a/src/types/rtti.rs
+++ b/src/types/rtti.rs
@@ -832,6 +832,11 @@ impl Enum {
     }
 
     #[inline]
+    pub fn variant_values(&self) -> &RedArray<i64> {
+        unsafe { mem::transmute(&self.0.valueList) }
+    }
+
+    #[inline]
     pub fn as_type(&self) -> &Type {
         unsafe { &*(self as *const _ as *const Type) }
     }


### PR DESCRIPTION
- use `hashList` instead of `aliasList` to get enum variant names
- expose enum variant values
- expose enum actual size